### PR TITLE
Add local directory to PATH for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
 import os
+import sys
 
+sys.path.append(".")
 from setupbase import (
     create_cmdclass,
     install_npm,
-    ensure_targets,
-    find_packages,
     combine_commands,
-    get_version,
-    HERE,
 )
 
 from setuptools import setup


### PR DESCRIPTION
This PR adds the local package directory to the environment PATH when setting up the package so that `setupbase` can be found correctly.