### PR TITLE
Use QuickLook rather than Scene Editor on iOS in examples

### DIFF
--- a/examples/leike.html
+++ b/examples/leike.html
@@ -89,7 +89,7 @@
         camera-orbit="0.9677rad 1.2427rad auto"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look fallback"
+        ar-modes="webxr quick-look"
         camera-controls
         alt="Testing visualization"
     >

--- a/examples/pertau.html
+++ b/examples/pertau.html
@@ -89,7 +89,7 @@
         camera-orbit="0.9677rad 1.2427rad auto"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look fallback"
+        ar-modes="webxr quick-look"
         camera-controls
         alt="Testing visualization"
     >

--- a/examples/radwave.html
+++ b/examples/radwave.html
@@ -89,7 +89,7 @@
         camera-orbit="0.9677rad 1.2427rad auto"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look fallback"
+        ar-modes="webxr quick-look"
         camera-controls
         alt="Testing visualization"
     >

--- a/examples/ring_colormap.html
+++ b/examples/ring_colormap.html
@@ -89,7 +89,7 @@
         camera-orbit="0.9677rad 1.2427rad auto"
         shadow-intensity="1"
         ar
-        ar-modes="webxr scene-viewer quick-look fallback"
+        ar-modes="webxr quick-look"
         camera-controls
         alt="Testing visualization"
     >


### PR DESCRIPTION
In my experience, QuickLook often does better with lighting and opacity than Scene Editor. While this has already been updated in the export code itself, this PR updates the examples to use QuickLook on iOS.